### PR TITLE
Include tests in tarball

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ license = "MIT"
 readme = "README.md"
 homepage = "https://github.com/pwwang/diot"
 repository = "https://github.com/pwwang/diot"
+include = ["tests/"]
 
 [tool.poetry.dependencies]
 python = "^3.6"


### PR DESCRIPTION
This PR updates `pyproject.toml` to include the `tests/` directory in the tarball produced by `poetry build`. This allows downstream packagers (e.g. conda) to use the tests to validate the build.